### PR TITLE
Update Policies for GitOps

### DIFF
--- a/clusters/managed-openshift-gitops/policies/openshift-gitops-subscription.yaml
+++ b/clusters/managed-openshift-gitops/policies/openshift-gitops-subscription.yaml
@@ -351,6 +351,72 @@ rules:
       - objectbucket.io
     resources:
       - '*'
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - policy.open-cluster-management.io
+    resources:
+      - policies
+      - placementbindings
+  - verbs:
+      - get 
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - apps.open-cluster-management.io
+    resources:
+      - placementrules
+  - verbs:
+      - '*'
+    apiGroups:
+      - automationcontroller.ansible.com
+    resources: 
+      - '*'
+  - verbs:
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - hco.kubevirt.io
+    resources: 
+      - hyperconvergeds
+  - verbs:
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - cdi.kubevirt.io
+    resources: 
+      - datavolumes
+  - verbs:
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - kubevirt.io
+    resources: 
+      - virtualmachines
+      - virtualmachineinstances
+      - virtualmachine-validator
+  - verbs:
+      - '*'
+    apiGroups:
+      - platform.stackrox.io
+    resources: 
+      - '*'
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -390,6 +456,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: open-cluster-management:cluster-manager-admin
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-gitops-cntk-argocd-application-controller-kubevirt
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-cntk-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirt.io:admin
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
@@ -437,6 +516,215 @@ spec:
       enabled: false
   initialSSHKnownHosts: {}
   resourceCustomizations: |
+    platform.stackrox.io/Central:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil and obj.status.conditions ~= nil then
+          for i, condition in ipairs(obj.status.conditions) do
+            if condition.status == "True" and (condition.reason == "InstallSuccessful" or condition.reason =="UpgradeSuccessful") then
+              hs.status = "Healthy"
+              hs.message = condition.message
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for Central to deploy."
+        return hs
+    cdi.kubevirt.io/DataVolume:
+      health.lua: |
+        hs = { status="Progressing", message="No status available"}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            hs.message = obj.status.phase
+            if hs.message == "Succeeded" then
+              hs.status = "Healthy"
+              return hs
+            elseif hs.message == "Failed" or hs.message == "Unknown" then
+              hs.status = "Degraded"
+            elseif hs.message == "Paused" then
+              hs.status = "Suspended"
+              return hs
+            end
+          end
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Running" and condition.status == "False" and condition.reason == "Error" then
+                hs.status = "Degraded"
+                hs.message = condition.message
+                return hs
+              end
+            end
+          end
+        end
+        return hs
+    hco.kubevirt.io/HyperConverged:
+      health.lua: |
+        hs = { status="Progressing", message="No status available"}
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Available" and condition.status == "True" then
+                hs.status = "Healthy"
+                hs.message = "Status is Available"
+              elseif condition.type == "Degraded" and condition.status == "True" then
+                hs.status = "Degraded"
+                hs.message = condition.reason
+              elseif condition.type == "Progressing" and condition.status == "True" then
+                hs.message = condition.reason
+              end
+            end
+          end
+          if obj.status.phase ~= nil then
+            hs.message = obj.status.phase
+          end
+        end
+        return hs
+    kubevirt.io/VirtualMachineInstance:
+      health.lua: |
+        hs = { status="Progressing", message="No status available"}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            hs.message = obj.status.phase
+            if hs.message == "Failed" then
+              hs.status = "Degraded"
+              return hs
+            elseif hs.message == "Pending" or hs.message == "Scheduling" or hs.message == "Scheduled" then
+              return hs
+            elseif hs.message == "Succeeded" then
+              hs.status = "Suspended"
+              return hs
+            elseif hs.message == "Unknown" then
+              hs.status = "Unknown"
+              return hs
+            end
+          end
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Ready" then
+                if condition.status == "True" then
+                  hs.status = "Healthy"
+                  hs.message = "Running"
+                else
+                  hs.status = "Degraded"
+                  hs.message = condition.message
+                end
+              elseif condition.type == "Paused" and condition.status == "True" then
+                hs.status = "Suspended"
+                hs.message = condition.message
+                return hs
+              end
+            end
+          end
+        end
+        return hs
+    kubevirt.io/VirtualMachine:
+      health.lua: |
+        hs = { status="Progressing", message="No status available"}
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Paused" and condition.status == "True" then
+                hs.status = "Suspended"
+                hs.message = "Paused"
+                return hs
+              end
+              if condition.type == "Ready" then
+                if condition.status == "True" then
+                  hs.status="Healthy"
+                  hs.message="Running"
+                else
+                  if obj.status.created then
+              hs.message = "Starting"
+                  else
+                    hs.status = "Suspended"
+                    hs.message = "Stopped"
+                  end
+                end
+              end
+            end
+          end
+          if obj.status.printableStatus ~= nil then
+            hs.message = obj.status.printableStatus
+          end
+        end
+        return hs
+    bitnami.com/SealedSecret:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Synced" and condition.status == "False" then
+                hs.status = "Degraded"
+                hs.message = condition.message
+                return hs
+              end
+              if condition.type == "Synced" and condition.status == "True" then
+                hs.status = "Healthy"
+                hs.message = condition.message
+                return hs
+              end
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for sync status"
+        return hs
+    build.openshift.io/BuildConfig:
+      ignoreDifferences: |
+        jsonPointers:
+        - /status/lastVersion
+    route.openshift.io/Route:
+      ignoreDifferences: |
+        jsonPointers:
+        - /status/ingress
+    ServiceAccount:
+      ignoreDifferences: |
+        jsonPointers:
+        - /imagePullSecrets
+    PersistentVolumeClaim:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            if obj.status.phase == "Pending" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+            if obj.status.phase == "Bound" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for certificate"
+        return hs
+    Job:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.active ~= nil then
+            if obj.status.active == "1" then
+              hs.status = "Progressing"
+              hs.message = obj.status.active .. " active job(s)."
+              return hs
+            end
+          end
+          if obj.status.succeeded ~= nil then
+            if obj.status.succeeded == 1 then
+              hs.status = "Healthy"
+              hs.message = "Job completed successfully."
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for Job to complete."
+        return hs
     argoproj.io/Application:
       ignoreDifferences: |
         jsonPointers:
@@ -519,7 +807,7 @@ spec:
         end
         hs.status = "Progressing"
         hs.message = "Unknown"
-        return hs                  
+        return hs            
   applicationSet:
     resources:
       limits:
@@ -530,6 +818,8 @@ spec:
         memory: 512Mi
   rbac: {}
   repo:
+    image: quay.io/benswinneyau/openshift-gitops-repo-server
+    version: latest
     resources:
       limits:
         cpu: '1'
@@ -562,6 +852,7 @@ spec:
       requests:
         cpu: 250m
         memory: 128Mi
+  kustomizeBuildOptions: '--enable-alpha-plugins'
   tls:
     ca: {}
   redis:


### PR DESCRIPTION
Policies did not reflect the deploy GitOps instance, so they ended up overwriting the deployed version.

Policies have now been updated to match.